### PR TITLE
fix: Don't exit when child process crashes

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: "npm run release"
 
 on:
   push:

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -19,5 +19,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build --if-present
-      - run: ls -la
       - run: npm test

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: "npm test"
 
 on:
   push:

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -19,4 +19,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build --if-present
+      - run: ls -la
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ supermon app.ts
 
 ```help
 Options:
-  --watchdir  Which directory to watch for changes                      [string]
-  --polling   Use polling (CPU and memory tax)                         [boolean]
-  --version   Show version number
-  --help      Show help
+  --watchdir        Which directory to watch for changes                [string]
+  --polling         Use polling (CPU and memory tax)                   [boolean]
+  --noFirstRunSync  Don't do full sync on first run                    [boolean]
+  --version         Show version number
+  --help            Show help
 
-Note: If supermon arguments are provided, it is recommended to use "--" as separator between supermon and executable
+Note: If supermon arguments are provided, it is recommended to use "--" as separator between supermon and application
 
 Note: [boolean] options do not require value to be specified
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test": "npm-run-all test:*",
     "test:eslint": "eslint --ext .js,.ts .",
     "test:tsc": "tsc --noEmit",
-    "test:jest": "jest .",
+    "test:jest": "npm run build && jest .",
     "build": "tsc",
     "prepublishOnly": "npm run build",
     "release": "semantic-release"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "scripts": {
     "dev": "tsc --watch",
     "dev-test-server": "supermon ./dist/test/apps/test-server.js",
+    "dev-help": "ts-node ./src/bin/cli.ts --help",
     "test": "npm-run-all test:*",
     "test:eslint": "eslint --ext .js,.ts .",
     "test:tsc": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "dev-test-server": "supermon ./dist/test/apps/test-server.js",
     "test": "npm-run-all test:*",
     "test:eslint": "eslint --ext .js,.ts .",
-    "jest": "jest .",
+    "test:tsc": "tsc --noEmit",
+    "test:jest": "jest .",
     "build": "tsc",
     "prepublishOnly": "npm run build",
     "release": "semantic-release"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test": "npm-run-all test:*",
     "test:eslint": "eslint --ext .js,.ts .",
     "test:tsc": "tsc --noEmit",
-    "test:jest": "npm run build && jest .",
+    "test:jest": "jest .",
     "build": "tsc",
     "prepublishOnly": "npm run build",
     "release": "semantic-release"

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -31,6 +31,10 @@ yargs
     type: 'boolean',
     describe: 'Use polling (CPU and memory tax)',
   })
+  .option('noFirstRunSync', {
+    type: 'boolean',
+    describe: "Don't do full sync on first run",
+  })
   .version(false) // Set custom version option to avoid "[boolean]" flag in help
   .option('version', {
     describe: 'Show version number',
@@ -67,6 +71,7 @@ const { argv } = yargs;
 lib({
   executable: argv._.join(' '),
   watchdir: argv.watchdir as string,
-  polling: argv.polling as boolean,
+  polling: !argv.noFirstRunSync as boolean,
+  firstRunSync: argv.firstRunSync as boolean,
   debug: argv.debug as boolean,
 });

--- a/src/lib/LibEventBus.ts
+++ b/src/lib/LibEventBus.ts
@@ -3,6 +3,8 @@ import EventBus from './utils/EventBus';
 
 export enum LibEvents {
   Started = 'Started',
+  Stopped = 'Stopped',
+  Restarted = 'Restarted',
 }
 
 export default class LibEventBus extends EventBus {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -21,7 +21,12 @@ export interface LibProps {
    *
    * Default: 200
    */
-    delay?: number;
+  delay?: number;
+
+  /**
+   * Wheter or not to do full sync on first run
+   */
+  firstRunSync?: boolean;
 }
 
 
@@ -44,6 +49,7 @@ export default ({
   delay = 200,
   logging = true,
   polling = false,
+  firstRunSync = true,
   watchdir = '.',
 }: LibProps): LibEventBus => {
   const isTypeScript = extname(executable) === '.ts';
@@ -71,7 +77,9 @@ export default ({
 
 
   // Setup installer
-  installEventBus = install();
+  installEventBus = install({
+    firstRunSync,
+  });
   installEventBus.on(installEventBus.Events.Install, () => {
     if (debug) {
       console.log('index, INSTALL');

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -95,8 +95,9 @@ export default (props: LibProps): LibEventBus => {
   runEventBus.on(runEventBus.Events.Stopped, () => {
     isStarted = false;
 
-    // Make sure we clean up all dangling processes
-    process.exit(0);
+    if (code === 0) {
+      // Make sure we clean up all dangling processes when application finishes
+      process.exit(0);
   });
   if (defaultedProps.logging) {
     runEventBus.pipe(logEventBus);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -93,7 +93,8 @@ export default ({
 
 
   // Setup the requested command
-  runEventBus = runRestartable(`${(isTypeScript ? 'ts-node' : 'node')} ${executable}`);
+  const engine = (isTypeScript ? 'ts-node' : 'node');
+  runEventBus = runRestartable(`${engine} ${executable}`);
   runEventBus.on(runEventBus.Events.Started, () => {
     libEventBus.emit(libEventBus.Events.Started); // Temporary
     isStarted = true;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,6 +12,15 @@ export interface LibProps {
   polling?: boolean;
   logging?: boolean;
   debug?: boolean;
+
+  /**
+   * How long to sleep (in ms) when file change event is detected
+   *
+   * Used to avoid triggering events on every file modifications on fe. `npm install`
+   *
+   * Default: 200
+   */
+    delay?: number;
 }
 
 
@@ -30,6 +39,7 @@ let isStarted = false;
 export default ({
   executable,
   debug = false,
+  delay = 200,
   logging = true,
   polling = false,
   watchdir = '.',
@@ -41,6 +51,7 @@ export default ({
     cwd: watchdir,
     polling,
     extensions: (isTypeScript ? ['ts', 'json'] : ['js', 'mjs', 'json']),
+    delay,
   });
   watchEventBus.on(watchEventBus.Events.FilesChanged, () => {
     if (debug) {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 import { extname } from 'path';
 import treeKill from 'tree-kill';
+import { existsSync } from 'fs';
 import { install, InstallEventBus } from './install';
 import { watch, WatchEventBus } from './watch';
 import { runRestartable, RunEventBus } from './run';
@@ -53,6 +54,10 @@ export default ({
   watchdir = '.',
 }: LibProps): LibEventBus => {
   const isTypeScript = extname(executable) === '.ts';
+
+  if (!existsSync(watchdir)) {
+    throw new Error(`Path "${watchdir}" does not exist.`);
+  }
 
   // Setup watcher
   watchEventBus = watch({

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -58,7 +58,7 @@ export default ({
   watchEventBus = watch({
     cwd: watchdir,
     polling,
-    extensions: (isTypeScript ? ['ts', 'json'] : ['js', 'mjs', 'json']),
+    extensions: (isTypeScript ? ['ts', 'tsx', 'json'] : ['js', 'mjs', 'jsx', 'json']),
     delay,
   });
   watchEventBus.on(watchEventBus.Events.FilesChanged, () => {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -106,6 +106,10 @@ export default ({
     isStarted = true;
   });
   runEventBus.on(runEventBus.Events.Restarted, () => {
+    if (debug) {
+      console.log('index, RESTARTED');
+    }
+
     libEventBus.emit(libEventBus.Events.Restarted);
   });
   runEventBus.on(runEventBus.Events.Stopped, (code) => {

--- a/src/lib/install/install.ts
+++ b/src/lib/install/install.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { satisfies } from 'semver';
 import { runOnce } from '../run';
-import DependencyDiff, { Diff } from './dependencyDiff';
+import dependencyDiff, { Diff } from './dependencyDiff';
 import LoadPackageJSON from './loadPackageJSON';
 import { set, get } from './store';
 import InstallEventBus from './InstallEventBus';
@@ -35,11 +35,11 @@ export default (): InstallEventBus => {
       // Do diff between stored and current package.json
       .then(() => {
         if (storedPackageJSON) {
-          const diffDependencies = DependencyDiff(
+          const diffDependencies = dependencyDiff(
             storedPackageJSON.dependencies,
             packageJSON.dependencies,
           );
-          const diffDevDependencies = DependencyDiff(
+          const diffDevDependencies = dependencyDiff(
             storedPackageJSON.devDependencies,
             packageJSON.devDependencies,
           );

--- a/src/lib/install/install.ts
+++ b/src/lib/install/install.ts
@@ -7,6 +7,12 @@ import LoadPackageJSON from './loadPackageJSON';
 import { set, get } from './store';
 import InstallEventBus from './InstallEventBus';
 
+type installProps = {
+  /**
+   * Wheter or not do to the first run full sync
+   */
+  firstRunSync: boolean;
+}
 
 let installEventBus: InstallEventBus;
 const cwd = '.';
@@ -14,7 +20,9 @@ const packageJSONPath = join(cwd, 'package.json');
 const nodeModulesPath = join(cwd, 'node_modules');
 
 
-export default (): InstallEventBus => {
+const install = ({
+  firstRunSync = true,
+}: installProps): InstallEventBus => {
   installEventBus = new InstallEventBus();
 
   installEventBus.on(installEventBus.Events.Install, () => {
@@ -85,9 +93,11 @@ export default (): InstallEventBus => {
       .then(async () => {
         if (!storedPackageJSON) {
           // No previously stored dependencies
-          console.log('First execution. Running full sync (install & prune)...');
-          await runOnce('npm install --no-audit');
-          await runOnce('npm prune');
+          if (firstRunSync) {
+            console.log('First execution. Running full sync (install & prune)...');
+            await runOnce('npm install --no-audit');
+            await runOnce('npm prune');
+          }
         } else if (storedPackageJSON && (missingDependencies.length || extraDependencies.length)) {
           console.log('Syncing dependencies...');
           // Previously stored dependencies with changes
@@ -125,3 +135,5 @@ export default (): InstallEventBus => {
 
   return installEventBus;
 };
+
+export default install;

--- a/src/lib/install/install.ts
+++ b/src/lib/install/install.ts
@@ -85,7 +85,7 @@ export default (): InstallEventBus => {
       .then(async () => {
         if (!storedPackageJSON) {
           // No previously stored dependencies
-          console.log('Could not find previous dependencies, running full sync (install & prune)...');
+          console.log('First execution. Running full sync (install & prune)...');
           await runOnce('npm install --no-audit');
           await runOnce('npm prune');
         } else if (storedPackageJSON && (missingDependencies.length || extraDependencies.length)) {

--- a/src/lib/run/Run.ts
+++ b/src/lib/run/Run.ts
@@ -69,18 +69,3 @@ export class Run {
     this.eventBus.emit(this.eventBus.Events.Started);
   }
 }
-
-
-// Make sure child is killed when process exits
-// TODO: Handle all the events, including exceptions
-// TODO: Test if this can be set within the Run function (does it set itself over and over again)
-// process.on('SIGINT', () => events.emit(Events.KILL));
-
-
-// const termSignals: NodeJS.Signals[] = ['SIGINT', 'SIGUSR1', 'SIGUSR2', 'SIGTERM'];
-// termSignals.forEach((eventType) => {
-//   process.on(eventType, () => {
-//     console.log('process exit no2, PID', child.pid);
-//     kill(child.pid)
-//   });
-// });

--- a/src/lib/run/RunEventBus.ts
+++ b/src/lib/run/RunEventBus.ts
@@ -5,6 +5,8 @@ export enum RunEvents {
   Start = 'Start',
   Started = 'Started',
   Restart = 'Restart',
+  Restarted = 'Restarted',
+  Stop = 'Stop',
   Stopped = 'Stopped',
 }
 

--- a/src/lib/run/runRestartable.ts
+++ b/src/lib/run/runRestartable.ts
@@ -12,8 +12,10 @@ export default (command: string): RunEventBus => {
   run.eventBus.on(run.eventBus.Events.Started, () => {
     if (isRestarting) {
       isRestarting = false;
+      runEventBus.emit(runEventBus.Events.Restarted);
+    } else {
+      runEventBus.emit(runEventBus.Events.Started);
     }
-    runEventBus.emit(runEventBus.Events.Started);
   });
 
   run.eventBus.on(run.eventBus.Events.Stopped, (code) => {

--- a/src/lib/watch/WatchEventBus.ts
+++ b/src/lib/watch/WatchEventBus.ts
@@ -6,6 +6,8 @@ export enum WatchEvents {
   FilesChanged = 'FilesChanged',
   Enable = 'Enable',
   Disable = 'Disable',
+  Stop = 'Stop',
+  Stopped = 'Stopped',
 }
 
 export default class WatchEventBus extends EventBus {

--- a/src/lib/watch/watch.ts
+++ b/src/lib/watch/watch.ts
@@ -4,24 +4,41 @@ import WatchEventBus from './WatchEventBus';
 
 export type WatchProps = {
   /**
-   * Working directory (default: '.')
+   * Working directory
+   *
+   * Default: '.'
    */
   cwd?: string;
 
   /**
-   * Whether or not to use file polling instead of FS events (default: false)
+   * Whether or not to use file polling instead of FS events
+   *
+   * Default: false
    */
   polling?: boolean;
 
   /**
-   * Which file extensions to watch (default: ['js', 'mjs', 'json'])
+   * Which file extensions to watch
+   *
+   * Default: ['js', 'mjs', 'json']
    */
   extensions?: Array<string>;
 
   /**
-   * Which paths to ignore (default: ['./node_modules', './docs'])
+   * Which paths to ignore
+   *
+   * Default: ['./node_modules', './docs']
    */
   ignore?: Array<string>;
+
+  /**
+   * How long to sleep (in ms) when file change event is detected
+   *
+   * Used to avoid triggering events on every file modifications on fe. `npm install`
+   *
+   * Default: 200
+   */
+  delay?: number;
 }
 
 
@@ -34,6 +51,7 @@ const watch = ({
   polling = false,
   extensions = ['js', 'mjs', 'json'],
   ignore = ['./node_modules', './docs'],
+  delay = 200,
 }: WatchProps): WatchEventBus => {
   // const defaultedProps = { ...watchPropsDefaults, ...props };
   let debounceTimer: NodeJS.Timeout;
@@ -53,7 +71,7 @@ const watch = ({
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         eventBus.emit(eventBus.Events.FilesChanged);
-      }, 200);
+      }, delay);
     }
   });
 

--- a/src/lib/watch/watch.ts
+++ b/src/lib/watch/watch.ts
@@ -83,6 +83,11 @@ const watch = ({
     isEnabled = false;
   });
 
+  eventBus.on(eventBus.Events.Stop, () => {
+    watcher.close();
+    eventBus.emit(eventBus.Events.Stopped);
+  });
+
   return eventBus;
 };
 

--- a/src/test/apps/test-wait.ts
+++ b/src/test/apps/test-wait.ts
@@ -17,4 +17,5 @@ setTimeout(() => {
   // Keep the app running for set time
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   temp += 1;
+  console.log(temp);
 }, waitInSeconds * 1000);

--- a/src/test/apps/test-wait.ts
+++ b/src/test/apps/test-wait.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Application for testing purposes
+ *
+ * Only waits for given amount of time
+ *
+ * Wait time can be defined as an cmd argument
+ * (fe. wait for 5 seconds `ts-node test-wait.ts 5`)
+ *
+ * Defaults to 1 second wait time
+ */
+const arg = process.argv.pop() as string;
+const waitInSeconds = parseInt(arg, 10) || 1; // Default to 1 second
+
+setTimeout(() => {
+  // Keep the app running for set time
+}, waitInSeconds * 1000);

--- a/src/test/apps/test-wait.ts
+++ b/src/test/apps/test-wait.ts
@@ -11,7 +11,10 @@
  */
 const arg = process.argv.pop() as string;
 const waitInSeconds = parseInt(arg, 10) || 1; // Default to 1 second
+let temp = 1;
 
 setTimeout(() => {
   // Keep the app running for set time
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  temp += 1;
 }, waitInSeconds * 1000);

--- a/src/test/lib/getWorkDir.ts
+++ b/src/test/lib/getWorkDir.ts
@@ -1,11 +1,18 @@
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync, rmdirSync } from 'fs';
 import { join } from 'path';
 
 const dirPath = join(__dirname, '..', '..', '..', 'tmp');
 
 export default (): string => {
-  if (!existsSync(dirPath)) {
+  try {
+    if (existsSync(dirPath)) {
+      rmdirSync(dirPath, { recursive: true });
+    }
     mkdirSync(dirPath);
+  } catch (err) {
+    // fs operations may fail silently
+    console.log(err);
+    throw err;
   }
 
   return dirPath;

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -34,7 +34,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
   });
 
   // Wait for some time since the first execution does full install
-}), 60 * 1000);
+}), 90 * 1000);
 
 afterAll(() => {
   // Make sure the process is killed

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -46,7 +46,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
   });
 
   // Wait for some time since the first execution does full install
-}), 20 * 1000);
+}));
 
 afterAll(() => {
   // Make sure the process is killed

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -35,7 +35,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
   });
 
   // Wait for some time since the first execution does full install
-}));
+}), 20 * 1000);
 
 afterAll(() => {
   // Make sure the process is killed

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -14,7 +14,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
   const appFile = join(workDir, '..', 'dist', 'test', 'apps', 'test-wait.js');
 
   eventBus = lib({
-    executable: `${appFile} 1`,
+    executable: `${appFile} 5`,
     watchdir: pathResolve(__dirname, '../../tmp'),
     delay: 10,
     logging: false,

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -19,6 +19,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
     delay: 10,
     logging: false,
     firstRunSync: false,
+    polling: true,
     debug: true,
   });
 

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -1,21 +1,31 @@
 import { writeFileSync } from 'fs';
-import { join, resolve as pathResolve } from 'path';
+import { join } from 'path';
 import getWorkDir from './lib/getWorkDir';
 import lib from '../lib';
 import LibEventBus from '../lib/LibEventBus';
 
-const workDir = getWorkDir();
-const touchFile = join(workDir, 'empty_touch_file.js');
-
+let workDir: string;
+let appFile: string;
+let touchFile: string;
 let eventBus: LibEventBus;
+
+beforeAll(() => {
+  workDir = getWorkDir();
+  appFile = join(workDir, '..', 'dist', 'test', 'apps', 'test-wait.js');
+  touchFile = join(workDir, 'empty_touch_file.js');
+
+  // Create the touchFile so that file watcher has something to watch
+  writeFileSync(touchFile, '0', { encoding: 'utf8' });
+});
 
 test('Application should restart on file change', () => new Promise<void>((resolve) => {
   // For some reason test doesn't work with .ts file (executed by ts-node)
-  const appFile = join(workDir, '..', 'dist', 'test', 'apps', 'test-wait.js');
+  appFile = join(workDir, '..', 'dist', 'test', 'apps', 'test-wait.js');
+  touchFile = join(workDir, 'empty_touch_file.js');
 
   eventBus = lib({
-    executable: `${appFile} 5`,
-    watchdir: pathResolve(__dirname, '../../tmp'),
+    executable: `${appFile} 1`,
+    watchdir: workDir,
     delay: 10,
     logging: false,
     firstRunSync: false,
@@ -24,17 +34,13 @@ test('Application should restart on file change', () => new Promise<void>((resol
   });
 
   eventBus.on(eventBus.Events.Started, () => {
-    console.log('started...');
     // Wait a bit to make sure watcher is initialized
     setTimeout(() => {
-      console.log(`touching (${touchFile})...`);
-      // writeFileSync(touchFile, `${process.hrtime.bigint()}`, { encoding: 'utf8' });
-      writeFileSync(touchFile, `${Math.random() * 10000}`, { encoding: 'utf8' });
+      writeFileSync(touchFile, `${process.hrtime.bigint()}`, { encoding: 'utf8' });
     }, 100);
   });
 
   eventBus.on(eventBus.Events.Restarted, () => {
-    console.log('restarting...');
     expect(true).toBeTruthy();
     resolve();
   });

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -19,7 +19,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
     delay: 10,
     logging: false,
     firstRunSync: false,
-    // debug: true,
+    debug: true,
   });
 
   eventBus.on(eventBus.Events.Started, () => {

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -1,55 +1,40 @@
-/* eslint-disable jest/no-done-callback */
-/* eslint-disable jest/no-conditional-expect */
 import { writeFileSync } from 'fs';
 import { join, resolve as pathResolve } from 'path';
-import { clean, getValue } from './apps/libs/incrementer';
 import getWorkDir from './lib/getWorkDir';
 import lib from '../lib';
 import LibEventBus from '../lib/LibEventBus';
 
 const workDir = getWorkDir();
-const appFile = join(workDir, '..', 'dist', 'test', 'apps', 'test-incrementer.js');
-const incrementFile = 'restart_incrementer';
 const touchFile = join(workDir, 'empty_touch_file.js');
-let isStarted = false;
-
 
 let eventBus: LibEventBus;
 
-beforeAll(() => {
-  clean(incrementFile);
-});
+test('Application should restart on file change', () => new Promise<void>((resolve) => {
+  // For some reason test doesn't work with .ts file (executed by ts-node)
+  const appFile = join(workDir, '..', 'dist', 'test', 'apps', 'test-wait.js');
 
-test('restart', (done) => {
   eventBus = lib({
-    executable: `${appFile} ${incrementFile}`,
+    executable: `${appFile} 1`,
     watchdir: pathResolve(__dirname, '../../tmp'),
-    // debug: true,
+    delay: 10,
     logging: false,
+    // debug: true,
   });
 
   eventBus.on(eventBus.Events.Started, () => {
-    if (!isStarted) {
-      isStarted = true;
-
-      expect(getValue(incrementFile)).toEqual(0);
-
-      // Wait a bit to make sure watcher is initialized
-      setTimeout(() => {
-        writeFileSync(touchFile, `${process.hrtime.bigint()}`, { encoding: 'utf8' });
-      }, 100);
-    } else {
-      // Wait a bit to make sure incrementer has written the file
-      setTimeout(() => {
-        expect(getValue(incrementFile)).toEqual(2);
-
-        // setTimeout(done, 100);
-        done();
-      }, 100);
-    }
+    // Wait a bit to make sure watcher is initialized
+    setTimeout(() => {
+      writeFileSync(touchFile, `${process.hrtime.bigint()}`, { encoding: 'utf8' });
+    }, 100);
   });
-}, 10 * 1000);
+
+  eventBus.on(eventBus.Events.Restarted, () => {
+    expect(true).toBeTruthy();
+    resolve();
+  });
+}));
 
 afterAll(() => {
+  // Make sure the process is killed
   eventBus.kill();
 });

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -20,15 +20,16 @@ test('Application should restart on file change', () => new Promise<void>((resol
     logging: false,
     firstRunSync: false,
     polling: true,
-    debug: true,
+    // debug: true,
   });
 
   eventBus.on(eventBus.Events.Started, () => {
     console.log('started...');
     // Wait a bit to make sure watcher is initialized
     setTimeout(() => {
-      console.log('touching...');
-      writeFileSync(touchFile, `${process.hrtime.bigint()}`, { encoding: 'utf8' });
+      console.log(`touching (${touchFile})...`);
+      // writeFileSync(touchFile, `${process.hrtime.bigint()}`, { encoding: 'utf8' });
+      writeFileSync(touchFile, `${Math.random() * 10000}`, { encoding: 'utf8' });
     }, 100);
   });
 

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -23,13 +23,16 @@ test('Application should restart on file change', () => new Promise<void>((resol
   });
 
   eventBus.on(eventBus.Events.Started, () => {
+    console.log('started...');
     // Wait a bit to make sure watcher is initialized
     setTimeout(() => {
+      console.log('touching...');
       writeFileSync(touchFile, `${process.hrtime.bigint()}`, { encoding: 'utf8' });
     }, 100);
   });
 
   eventBus.on(eventBus.Events.Restarted, () => {
+    console.log('restarting...');
     expect(true).toBeTruthy();
     resolve();
   });

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -44,8 +44,6 @@ test('Application should restart on file change', () => new Promise<void>((resol
     expect(true).toBeTruthy();
     resolve();
   });
-
-  // Wait for some time since the first execution does full install
 }));
 
 afterAll(() => {

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -32,7 +32,9 @@ test('Application should restart on file change', () => new Promise<void>((resol
     expect(true).toBeTruthy();
     resolve();
   });
-}));
+
+  // Wait for some time since the first execution does full install
+}), 30 * 1000);
 
 afterAll(() => {
   // Make sure the process is killed

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -18,6 +18,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
     watchdir: pathResolve(__dirname, '../../tmp'),
     delay: 10,
     logging: false,
+    firstRunSync: false,
     // debug: true,
   });
 
@@ -34,7 +35,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
   });
 
   // Wait for some time since the first execution does full install
-}), 90 * 1000);
+}));
 
 afterAll(() => {
   // Make sure the process is killed

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -19,7 +19,7 @@ beforeAll(() => {
 });
 
 test('Application should restart on file change', () => new Promise<void>((resolve) => {
-  // For some reason test doesn't work with .ts file (executed by ts-node)
+  // The test doesn't work with .ts app file (executed by ts-node)
   appFile = join(workDir, '..', 'dist', 'test', 'apps', 'test-wait.js');
   touchFile = join(workDir, 'empty_touch_file.js');
 

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -34,7 +34,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
   });
 
   // Wait for some time since the first execution does full install
-}), 30 * 1000);
+}), 60 * 1000);
 
 afterAll(() => {
   // Make sure the process is killed


### PR DESCRIPTION
Feature for this release
- Process exists only when child process has clean exit (code 0), if the child process crashes the main watcher process will keep running
- Added option to skip the full dependency sync on first execution
- Fixed jest test for child process restart on file changes and added the test to `npm test` suite