### PR TITLE
fix(module-sync): Handle dependencies as optional

### DIFF
--- a/src/lib/modules/index.ts
+++ b/src/lib/modules/index.ts
@@ -19,7 +19,6 @@ type modulesProps = {
   firstRunSync: boolean;
 }
 
-// let installEventBus: InstallEventBus;
 const cwd = '.';
 const packageJSONPath = join(cwd, 'package.json');
 const nodeModulesPath = join(cwd, 'node_modules');
@@ -48,12 +47,12 @@ const modules = ({
       .then(() => {
         if (storedPackageJSON) {
           const diffDependencies = dependencyDiff(
-            storedPackageJSON.dependencies,
-            packageJSON.dependencies,
+            storedPackageJSON.dependencies || {},
+            packageJSON.dependencies || {},
           );
           const diffDevDependencies = dependencyDiff(
-            storedPackageJSON.devDependencies,
-            packageJSON.devDependencies,
+            storedPackageJSON.devDependencies || {},
+            packageJSON.devDependencies || {},
           );
           // Combine dependency diffs
           missingDependencies = missingDependencies.concat(
@@ -129,10 +128,8 @@ const modules = ({
         }, 0);
       })
 
-      .catch((err) => {
-        eventBus.emit(LogEvents.Message, 'Error:', err);
-
-        throw new Error('Failed dependency sync.');
+      .catch(() => {
+        eventBus.emit(LogEvents.Message, 'Failed dependency sync.');
       });
   });
 };

--- a/src/lib/modules/types/PackageJSON.ts
+++ b/src/lib/modules/types/PackageJSON.ts
@@ -3,7 +3,7 @@ import { DependencyMap } from './DependencyMap';
 export interface PackageJSON extends Object {
   readonly name: string;
   readonly version: string;
-  readonly dependencies: DependencyMap;
-  readonly devDependencies: DependencyMap;
-  readonly peerDependencies: DependencyMap;
+  readonly dependencies?: DependencyMap;
+  readonly devDependencies?: DependencyMap;
+  readonly peerDependencies?: DependencyMap;
 }


### PR DESCRIPTION
Not every project has all dependency objects, handle them as optional (default to empty dependency object(