### PR TITLE
feat: Update CLI options to follow nodemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
   "engines": {
     "node": ">=8"
   },
-  "keywords": [],
+  "keywords": [
+    "monitor",
+    "restart",
+    "development",
+    "typescript"
+  ],
   "author": {
     "name": "Mikko Tikkanen",
     "email": "mikko.tikkanen@gmail.com"
@@ -53,6 +58,7 @@
     "dev-test-server": "ts-node ./src/bin/cli.ts ./dist/test/apps/test-server.js --debug",
     "dev-test-lib": "ts-node ./src/bin/cli.ts",
     "dev-test-help": "ts-node ./src/bin/cli.ts --help",
+    "dev-test-version": "ts-node ./src/bin/cli.ts --version",
     "test": "npm-run-all test:*",
     "test:eslint": "eslint --ext .js,.ts .",
     "test:tsc": "tsc --noEmit",

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -67,7 +67,7 @@ if (yargs.argv.version) {
 if (yargs.argv.help) {
   yargs.showHelp('log');
   console.log('');
-  console.log('Note: If supermon arguments are provided, it is recommended to use "--" as separator between supermon and application');
+  console.log('Note: If supermon arguments are provided, it is recommended to use "--" as separator between supermon and application command');
   console.log('');
   console.log('Note: Boolean options do not require value to be specified');
   console.log('');

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -75,7 +75,7 @@ if (yargs.argv.help) {
   console.log('      "SUPERMON_" prefix. (fe. "SUPERMON_LEGACYWATCH=true")');
   console.log('');
   console.log('Example use: "supermon app.js"');
-  console.log('Example use: "supermon --watchdir=dist -- app.js --port=80"');
+  console.log('Example use: "supermon --watch=dist -- app.js --port=80"');
   process.exit(); /* eslint-disable-line no-process-exit */
 }
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -111,6 +111,6 @@ lib({
   ext,
   exec,
   legacywatch: args.legacywatch,
-  skipFirstSync: !args.skipfirstsync,
+  skipFirstSync: args.skipfirstsync,
   watch: args.watch,
 });

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -15,19 +15,29 @@ yargs
   })
   .env('SUPERMON')
   .option('watchdir', {
-    type: 'string',
+    // type: 'string',
     describe: 'Which directory to watch for changes',
+    default: '.',
+  })
+  .option('extensions', {
+    // type: 'string',
+    describe: 'Comma separated list of file extensions to watch',
+  })
+  .option('delay', {
+    // type: 'number',
+    describe: 'How many ms to wait after file changes',
+    default: 200,
   })
   .option('polling', {
-    type: 'boolean',
+    // type: 'boolean',
     describe: 'Use polling (CPU and memory tax)',
   })
   .option('noFirstRunSync', {
-    type: 'boolean',
+    // type: 'boolean',
     describe: "Don't do full sync on first run",
   })
   .option('debug', {
-    type: 'boolean',
+    // type: 'boolean',
     describe: 'Show debug information',
   })
   .version(false) // Set custom version option to avoid "[boolean]" flag in help
@@ -70,10 +80,18 @@ if (pckg) {
 
 
 const { argv } = yargs;
+
+let extensions;
+if (argv.extensions) {
+  extensions = (argv.extensions as string || '').split(',');
+}
+
 lib({
   command: argv._.join(' '),
-  watchdir: argv.watchdir as string,
-  polling: !argv.noFirstRunSync as boolean,
-  firstRunSync: argv.firstRunSync as boolean,
   debug: argv.debug as boolean,
+  delay: argv.delay as number,
+  extensions,
+  firstRunSync: argv.firstRunSync as boolean,
+  polling: !argv.noFirstRunSync as boolean,
+  watchdir: argv.watchdir as string,
 });

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -72,7 +72,7 @@ if (yargs.argv.help) {
   console.log('Note: Boolean options do not require value to be specified');
   console.log('');
   console.log('Note: All options can also be configured through environment variables with');
-  console.log('      "SUPERMON_" prefix. (fe. "SUPERMON_POLLING=true")');
+  console.log('      "SUPERMON_" prefix. (fe. "SUPERMON_LEGACYWATCH=true")');
   console.log('');
   console.log('Example use: "supermon app.js"');
   console.log('Example use: "supermon --watchdir=dist -- app.js --port=80"');

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -90,7 +90,7 @@ if (pckg) {
 const { argv: args } = argv;
 
 let exec = args.exec || 'node';
-const command = args._.join(' ');
+let command = args._.join(' ');
 let ext = args.ext || ['js', 'mjs', 'jsx', 'json'];
 
 // Handle TypeScript commands
@@ -100,7 +100,8 @@ if (extname(command) === '.ts') {
 }
 // Handle NPM script as command
 if (command.match(/^npm /)) {
-  exec = ''; // Npm command includes executable (fe. "npm run dev")
+  exec = 'npm';
+  command = command.replace('npm ', '');
 }
 
 lib({

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -32,7 +32,6 @@ const argv = yargs
   })
   .option('exec', {
     describe: 'Executable to run the command on',
-    // default: '(ts-)node',
     type: 'string',
   })
   .option('legacywatch', {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,9 +33,9 @@ export interface LibProps {
   delay?: number;
 
   /**
-   * Executable to dun the command with
+   * Executable to run the command with
    *
-   * Default: node
+   * Default: "node"
    */
   exec?: string;
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -76,13 +76,15 @@ let isBeingKilled = false;
 
 /**
  * Setup main process
+ *
+ * Set sensible defaults
  */
 export default ({
   command,
   debug = false,
   delay = 200,
   exec = 'node',
-  ext,
+  ext = ['js', 'mjs', 'jsx', 'json'],
   skipFirstSync = true,
   logging = true,
   legacywatch = false,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -20,28 +20,6 @@ export interface LibProps {
   command: string;
 
   /**
-   * Directory to watch file events for
-   */
-  watchdir?: string;
-
-  /**
-   * File extensions to watch
-   */
-  extensions?: string[];
-
-  /**
-   * Use polling instead of file system events
-   *
-   * Useful for fe. running on Docker container where FS events arent propagated to host
-   */
-  polling?: boolean;
-
-  /**
-   * Log things to console
-   */
-  logging?: boolean;
-
-  /**
    * Debug flag. Log all events to console
    */
   debug?: boolean;
@@ -56,11 +34,33 @@ export interface LibProps {
   delay?: number;
 
   /**
+   * File extensions to watch
+   */
+  extensions?: string[];
+
+  /**
    * Wheter or not to do full sync on first run
    *
    * Default: true
    */
   firstRunSync?: boolean;
+
+  /**
+   * Log things to console
+   */
+  logging?: boolean;
+
+  /**
+   * Use polling instead of file system events
+   *
+   * Useful for fe. running on Docker container where FS events arent propagated to host
+   */
+  polling?: boolean;
+
+  /**
+   * Directory to watch file events for
+   */
+  watchdir?: string;
 }
 
 
@@ -75,11 +75,11 @@ export default ({
   command,
   debug = false,
   delay = 200,
+  extensions,
+  firstRunSync = true,
   logging = true,
   polling = false,
-  firstRunSync = true,
   watchdir = '.',
-  extensions,
 }: LibProps): EventBus => {
   // Default to node
   let executable = 'node';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -85,7 +85,7 @@ export default ({
   delay = 200,
   exec = 'node',
   ext = ['js', 'mjs', 'jsx', 'json'],
-  skipFirstSync = true,
+  skipFirstSync = false,
   logging = true,
   legacywatch = false,
   watch: watchdir = '.',

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -104,8 +104,11 @@ export default ({
 
   const props: LibProps = {
     command,
-    watch: watchdir,
+    delay,
+    exec,
     ext,
+    legacywatch,
+    watch: watchdir,
   };
   eventBus.emit(ProcessEvents.Start, props);
 

--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -46,8 +46,8 @@ const logger = ({
    */
   eventBus.on(ProcessEvents.Start, ({
     command: executable,
-    watchdir,
-    extensions,
+    watch: watchdir,
+    ext: extensions,
   }: LibProps) => {
     const pckg = loadPackageJSON(join(__dirname, '..', '..', '..', 'package.json'));
     if (!pckg) {

--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -45,9 +45,12 @@ const logger = ({
    * Process events
    */
   eventBus.on(ProcessEvents.Start, ({
-    command: executable,
-    watch: watchdir,
-    ext: extensions,
+    command,
+    exec,
+    ext,
+    delay,
+    legacywatch,
+    watch,
   }: LibProps) => {
     const pckg = loadPackageJSON(join(__dirname, '..', '..', '..', 'package.json'));
     if (!pckg) {
@@ -56,9 +59,13 @@ const logger = ({
 
     log();
     log(`v${pckg.version}`);
-    log(`Child process: ${executable}`);
-    log(`Watching directory: ${watchdir}`);
-    log(`Watching extensions: ${extensions?.join(',')}`);
+    log(`Child process: ${exec} ${command}`);
+    log(`Watching directory: ${watch}`);
+    log(`Watching extensions: ${ext?.join(',')}`);
+    log(`Watch delay: ${delay}ms`);
+    if (legacywatch) {
+      log('Using legacywatch');
+    }
     log();
   });
 

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -27,11 +27,11 @@ test('Application should restart on file change', () => new Promise<void>((resol
 
   eventBus = lib({
     command: `${appFile} 1`,
-    watchdir: workDir,
+    watch: workDir,
     delay: 10,
     logging: false,
-    firstRunSync: false,
-    polling: true,
+    skipFirstSync: false,
+    legacywatch: true,
     // debug: true,
   });
 

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -30,7 +30,7 @@ test('Application should restart on file change', () => new Promise<void>((resol
     watch: workDir,
     delay: 10,
     logging: false,
-    skipFirstSync: false,
+    skipFirstSync: true,
     legacywatch: true,
     // debug: true,
   });


### PR DESCRIPTION
Updated CLI options to follow same wording as nodemon uses

feat: Added `--exec=` option
feat: Added `--ext=` option
feat: Added `--delay=` option

BREAKING CHANGE: `--watchdir=` is now `--watch=`
BREAKING CHANGE: `--polling` is now `--legacywatch`
BREAKING CHANGE: `--noFirstRunSync` is now `--skipfirstsync`