### PR TITLE
chore: Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true


### PR DESCRIPTION
## Summary
Add dependabot config

## Reasons for making this change
In order to have dependabot PRs to have conventional commits for easier merging