### PR TITLE
feat: Short options and optional nodemon configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ npm install ts-node --save-dev
 
 ```bash
 supermon [application file]
-supermon [npm script command]
 ```
 
 Examples
@@ -39,7 +38,8 @@ Examples
 ```bash
 supermon app.js
 supermon app.ts
-supermon npm run server
+supermon --delay=2000 app.ts
+supermon --delay=2000 -- app.ts --port=80
 ```
 
 ## Options

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -60,7 +60,7 @@ const argv = yargs
   })
   .option('delay', {
     describe: 'How many ms to wait after file changes',
-    default: 200,
+    default: 1000,
     type: 'number',
   })
   .option('exec', {

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -22,16 +22,19 @@ const argv = yargs
     describe: 'Directory to watch for file changes',
     default: '.',
     type: 'string',
-  })
-  .option('ignore', {
-    describe: 'Directories to ignore for file changes',
-    type: 'string',
-    array: true,
+    alias: 'w',
   })
   .option('ext', {
     describe: 'Comma separated list of file extensions to watch',
     type: 'string',
     array: true,
+    alias: 'e',
+  })
+  .option('ignore', {
+    describe: 'Directories to ignore for file changes',
+    type: 'string',
+    array: true,
+    alias: 'i',
   })
   .option('delay', {
     describe: 'How many ms to wait after file changes',
@@ -41,10 +44,12 @@ const argv = yargs
   .option('exec', {
     describe: 'Executable to run the command on',
     type: 'string',
+    alias: 'x',
   })
   .option('legacywatch', {
     describe: 'Use polling instead of FS events',
     type: 'boolean',
+    alias: ['L', 'legacy-watch'],
   })
   .option('pmexec', {
     describe: 'Package manager executable to use',
@@ -68,6 +73,7 @@ const argv = yargs
   .option('debug', {
     describe: 'Show debug information',
     type: 'boolean',
+    alias: ['V', 'verbose'],
   });
 
 // Show help and version manually
@@ -100,6 +106,7 @@ if (pckg) {
 
 
 const { argv: args } = argv;
+// args.legacywatch = args.legacyWatch || args.legacywatch;
 
 let exec = args.exec || 'node';
 let command = args._.join(' ');

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -16,18 +16,20 @@ const argv = yargs
   })
   .env('SUPERMON')
   .config('config', 'Path to JSON config file', (filename: string) => {
-    let file = '';
+    // Try reading potential config file
+    let stringConfig = '';
     if (filename && existsSync(filename)) {
-      file = readFileSync(filename, { encoding: 'utf8' });
+      stringConfig = readFileSync(filename, { encoding: 'utf8' });
     } else if (existsSync('nodemon.json')) {
       // If no config was found, try reading nodemon.json as well
-      file = readFileSync('nodemon.json', { encoding: 'utf8' });
+      stringConfig = readFileSync('nodemon.json', { encoding: 'utf8' });
     }
 
+    // Try parsing the loaded file
     let config = {};
-    if (file) {
+    if (stringConfig) {
       try {
-        config = JSON.parse(file);
+        config = JSON.parse(stringConfig);
       } catch (err) {
         console.error('Error parsing JSON configuration:', err.toString());
         console.error('Try using a JSON validator.');


### PR DESCRIPTION
## Summary
- Added extra short options that mirror nodemon's options
- Added optional reading of nodemon configuration files if supermon configurations are not found

## Reasons for making this change
In order to make migration to nodemon to supermon as easy as possible